### PR TITLE
perf: optimize test return results

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package gin_unit_test
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -119,8 +121,12 @@ func TestHandlerUnMarshalResp(method string, uri string, way string, param inter
 	if err != nil {
 		return err
 	}
-
-	return json.Unmarshal(bodyByte, resp)
+	err = json.Unmarshal(bodyByte, resp)
+	if err != nil {
+		errorMsg := fmt.Sprintf("errmsg: %v, response body: %s", err, string(bodyByte))
+		return errors.New(errorMsg)
+	}
+	return err
 }
 
 func TestFileHandlerUnMarshalResp(method, uri, fileName string, filedName string, param interface{}, resp interface{}) error {


### PR DESCRIPTION
Change the return value of `TestHandlerUnMarshalResp` to a more detailed message. Like
```
errmsg: invalid character 'p' after top-level value, response body: 404 page not found
```
This allows users to discover the real cause of test errors from troubling error messages.

The motivation is as follows:
I currently test my codes and get a confusing returned error
```
invalid character 'p' after top-level value
```
My test codes are like
```
pReq := MyModel{Id: 1, Name: "alice"}
type OrdinaryResponse struct {
	Errno  string `json:"errno"`
	Errmsg string `json:"errmsg"`
}

resp := OrdinaryResponse{}
err := unitTest.TestHandlerUnMarshalResp("PUT", "/api/v1/admin", "json", pReq, &resp)
```
I get this error in test
```
my_test.go:22: TestMyAdmin: invalid character 'p' after top-level value
```
It should be caused by `json.Unmarshal` error, but it's hard for me to find out the mistake in my code.
After I add some log print in `gin_unit_test`, I found the `bodyByte` is `404 page not found` (caused by the unregister route). And this is the basically reason of `invalid character 'p' after top-level value`.
So it would be great if you could modify the return error message of `TestHandlerUnMarshalResp`.
Great project, thanks!
